### PR TITLE
add preprint Mondal and Jagtap (2026)

### DIFF
--- a/index.md
+++ b/index.md
@@ -125,6 +125,10 @@ listed above. Author names of Trixi.jl's main developers are in *italics*.
 
 ### 2026
 
+* Mondal, Jagtap,
+  **MARUT: An Exascale-Ready, GPU-Accelerated High-Order CFD Framework with AMR for High-Speed Flows and Finite-Rate Chemistry**, 2026.\\
+  [![arXiv:2605.26388](https://img.shields.io/badge/arXiv-2605.26388-yellow)](https://arxiv.org/abs/2605.26388)
+
 * Babbar, Churavy, *Schlottke-Lakemper*, *Ranocha*,
   **Automatic differentiation for performing the Cauchy-Kovalevskaya procedure in Lax-Wendroff type discretizations**,
   Journal of Computational Physics (563) 115101, 2026.\\


### PR DESCRIPTION
In the third version, they wrote that their code is based on Trixi.jl.